### PR TITLE
Performance improvements

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 ]}.
 
 {deps,
- [{hpack, {pkg, hpack_erl}}]}.
+ [{hpack, {git, "https://github.com/novalabsxyz/hpack.git", {branch, "adt/perf"}}}]}.
 
 {cover_enabled, true}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,4 @@
-{"1.2.0",
-[{<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},0}]}.
-[
-{pkg_hash,[
- {<<"hpack">>, <<"17670F83FF984AE6CD74B1C456EDDE906D27FF013740EE4D9EFAA4F1BF999633">>}]},
-{pkg_hash_ext,[
- {<<"hpack">>, <<"06F580167C4B8B8A6429040DF36CC93BBA6D571FAEAEC1B28816523379CBB23A">>}]}
-].
+[{<<"hpack">>,
+  {git,"https://github.com/novalabsxyz/hpack.git",
+       {ref,"291f83c8efbd50cf57ddcf311e5d9a4fbe2bb5cb"}},
+  0}].

--- a/src/chatterbox_static_stream.erl
+++ b/src/chatterbox_static_stream.erl
@@ -10,6 +10,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -150,6 +151,10 @@ on_end_stream(State=#cb_static{connection_pid=ConnPid,
             ct:pal("done sending body ~p", [StreamId])
     end,
 
+    {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("got unknown info ~p", [Event]),
     {ok, State}.
 
 terminate(_State) ->

--- a/src/chatterbox_static_stream.erl
+++ b/src/chatterbox_static_stream.erl
@@ -36,7 +36,6 @@ on_receive_data(_Bin, State)->
 
 on_end_stream(State=#cb_static{connection_pid=ConnPid,
                                        stream_id=StreamId}) ->
-    ct:pal("end stream"),
     Headers = State#cb_static.req_headers,
 
     Method = proplists:get_value(<<":method">>, Headers),
@@ -141,20 +140,16 @@ on_end_stream(State=#cb_static{connection_pid=ConnPid,
 
     case {Method, HeadersToSend, BodyToSend} of
         {<<"HEAD">>, _, _} ->
-            ct:pal("sending headers ~p ~p", [HeadersToSend, self()]),
                 h2_connection:send_headers(ConnPid, StreamId, HeadersToSend, [{send_end_stream, true}]);
         %%{<<"GET">>, _, _} ->
         _ ->
-            ct:pal("sending headers ~p ~p, body follows ~p", [StreamId, HeadersToSend, self()]),
             h2_connection:send_headers(ConnPid, StreamId, HeadersToSend),
-            h2_connection:send_body(ConnPid, StreamId, BodyToSend),
-            ct:pal("done sending body ~p", [StreamId])
+            h2_connection:send_body(ConnPid, StreamId, BodyToSend)
     end,
 
     {ok, State}.
 
-handle_info(Event, State) ->
-    ct:pal("got unknown info ~p", [Event]),
+handle_info(_Event, State) ->
     {ok, State}.
 
 terminate(_State) ->

--- a/src/h2_client.erl
+++ b/src/h2_client.erl
@@ -182,12 +182,10 @@ stop(Pid) ->
 sync_request(CliPid, Headers, Body) ->
     case send_request(CliPid, Headers, Body) of
         {ok, StreamId} ->
-            ct:pal("waiting for END_STREAM ~p ~p", [StreamId, self()]),
             receive
                 {'END_STREAM', StreamId} ->
                     h2_connection:get_response(CliPid, StreamId)
             after 5000 ->
-                      ct:pal("timed out waiting for END_STREAM ~p ~p", [StreamId, self()]),
                       {error, timeout}
             end;
         Error ->
@@ -202,11 +200,8 @@ send_request(CliPid, Headers, Body) ->
         {error, _Code} = Err ->
             Err;
         {StreamId, _} ->
-            ct:pal("spawned new stream ~p", [StreamId]),
             h2_connection:send_headers(CliPid, StreamId, Headers),
-            ct:pal("sent headers ~p", [StreamId]),
             h2_connection:send_body(CliPid, StreamId, Body),
-            ct:pal("sent body"),
             {ok, StreamId}
     end.
 

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1452,7 +1452,7 @@ go_away_(ErrorCode, Socket, Streams) ->
     go_away_(ErrorCode, <<>>, Socket, Streams).
 
 go_away_(ErrorCode, Reason, Socket, Streams) ->
-    ct:pal("sending goaway ~p ~p", [ErrorCode, Reason]),
+    ct:pal("~p ~p sending goaway ~p ~p", [self(), h2_stream_set:stream_set_type(Streams), ErrorCode, Reason]),
     NAS = h2_stream_set:get_next_available_stream_id(Streams),
     GoAway = h2_frame_goaway:new(NAS, ErrorCode, Reason),
     GoAwayBin = h2_frame:to_binary({#frame_header{
@@ -1611,8 +1611,8 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                          Streams),
                                                                        F(S, St, false, Decoder)
                                                                end;
-                                                           _ ->
-                                                               go_away_(?PROTOCOL_ERROR, <<"data on inactive stream">>, S, St),
+                                                           Type ->
+                                                               go_away_(?PROTOCOL_ERROR, list_to_binary(io_lib:format("data on ~p stream ~p", [Type, Header#frame_header.stream_id])), S, St),
                                                                Connection ! {go_away, ?PROTOCOL_ERROR}
                                                        end
                                                end;

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1655,7 +1655,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                        F(S, St, false, Decoder)
                                                                end;
                                                            StreamType ->
-                                                               ct:pal("unexpected ~p", [Frame]),
+                                                               ct:pal("unexpected data ~p", [Frame]),
                                                                go_away_(?PROTOCOL_ERROR, list_to_binary(io_lib:format("data on ~p stream ~p", [StreamType, Header#frame_header.stream_id])), S, St),
                                                                Connection ! {go_away, ?PROTOCOL_ERROR}
                                                        end

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -746,6 +746,7 @@ route_frame(Event, {H, _Payload},
               }}, ok)
                                                               end);
         _X ->
+            ct:pal("invalid settings ack"),
             maybe_reply(Event, {next_state, closing, Conn}, ok)
     end;
 
@@ -1248,6 +1249,7 @@ handle_event(info, {ssl_error, Socket, Reason},
               }=Conn) ->
     handle_socket_error(Reason, Conn);
 handle_event(info, {go_away, ErrorCode}, Conn) ->
+    ct:pal("sent goaway ~p", [ErrorCode]),
     gen_statem:cast(self(), io_lib:format("GO_AWAY: ErrorCode ~p", [ErrorCode])),
     {next_state, closing, Conn};
 %handle_event(info, {_,R},
@@ -1389,6 +1391,7 @@ go_away(Event, ErrorCode, Conn) ->
     go_away(Event, ErrorCode, <<>>, Conn).
 
 go_away(Event, ErrorCode, Reason, Conn) ->
+    ct:pal("sending goaway ~p ~p", [ErrorCode, Reason]),
     go_away_(ErrorCode, Reason, Conn#connection.socket, Conn#connection.streams),
     %% TODO: why is this sending a string?
     gen_statem:cast(self(), io_lib:format("GO_AWAY: ErrorCode ~p", [ErrorCode])),
@@ -1805,6 +1808,7 @@ start_http2_server(
              send_settings(Http2Settings, NewState)
             };
         {error, invalid_preface} ->
+            ct:pal("invalid preface"),
             {next_state, closing, Conn}
     end.
 

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -964,6 +964,7 @@ handle_event(_, {stream_finished,
                     {client, false} -> {Headers, Body, Trailers};
                     {client, true} -> garbage
                 end,
+                ct:pal("stream ~p finished", [StreamId]),
             {_NewStream, NewStreams} =
                 h2_stream_set:close(
                   Stream,

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1598,7 +1598,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                        %% TODO: RST_STREAM support
                                                        F(S, St, false, Decoder)
                                                end;
-                                           ?PING when StreamId == 0 ->
+                                           ?PING when StreamId /= 0 ->
                                                go_away_(?PROTOCOL_ERROR, S, St),
                                                Connection ! {go_away, ?PROTOCOL_ERROR};
                                            ?PING when Header#frame_header.length /= 8 ->

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1439,6 +1439,7 @@ send_headers_(StreamId, Headers, Opts, Streams) ->
                                                               h2_stream_set:update_encode_context(Streams, NewContext)
                                                       end,
                                                       sock:send(Socket, [h2_frame:to_binary(Frame) || Frame <- FramesToSend]),
+                                                      ct:pal("sent headers on stream ~p (complete ~p)", [StreamId, StreamComplete]),
                                                       send_h(Stream, Headers),
                                                       ok
                                               end);

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1496,7 +1496,6 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                L = Header#frame_header.length,
                                                case L > h2_stream_set:socket_recv_window_size(St) of
                                                    true ->
-                                                       ct:pal("window size violation ~p ~p", [L, h2_stream_set:socket_recv_window_size(St)]),
                                                        go_away_(?FLOW_CONTROL_ERROR, S, St);
                                                    false ->
                                                        Stream = h2_stream_set:get(Header#frame_header.stream_id, Streams),
@@ -1509,7 +1508,6 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                  L > 0
                                                                 } of
                                                                    {true, _, _} ->
-                                                                       ct:pal("stream window violation, resetting stream"),
                                                                        rst_stream__(Stream,
                                                                                    ?FLOW_CONTROL_ERROR,
                                                                                    S);
@@ -1537,7 +1535,6 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                        F(S, St, false, Decoder)
                                                                end;
                                                            _ ->
-                                                               ct:pal("not active stream ~p", [Stream]),
                                                                go_away_(?PROTOCOL_ERROR, S, St)
                                                        end
                                                end;
@@ -1601,7 +1598,6 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                            %% TODO ACK'd pings
                                            %% TODO stream window updates (need to share send window size)
                                            _ ->
-                                               ct:pal("other frame ~p", [Frame]),
                                                gen_statem:call(Connection, {frame, Frame}),
                                                F(S, St, false, Decoder)
                                        end

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1490,7 +1490,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                        case Header#frame_header.type of
                                            %% The first frame should be the client settings as per
                                            %% RFC-7540#3.5
-                                           Type when Type /= ?SETTINGS andalso First ->
+                                           HType when HType /= ?SETTINGS andalso First ->
                                                go_away_(?PROTOCOL_ERROR, S, St);
                                            ?DATA ->
                                                L = Header#frame_header.length,

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -309,10 +309,10 @@ send_headers(Pid, StreamId, Headers) ->
 send_headers(Pid, StreamId, Headers, Opts) ->
     send_headers_(StreamId, Headers, Opts, Pid).
 
--spec rst_stream(pid(), stream_id(), error_code()) -> ok.
-rst_stream(Pid, StreamId, ErrorCode) ->
-    gen_statem:cast(Pid, {rst_stream, StreamId, ErrorCode}),
-    ok.
+-spec rst_stream(h2_stream_set:stream_set(), stream_id(), error_code()) -> ok.
+rst_stream(Streams, StreamId, ErrorCode) ->
+    Stream = h2_stream_set:get(StreamId, Streams),
+    rst_stream__(Stream, ErrorCode, h2_stream_set:socket(Streams)).
 
 -spec send_trailers(h2_stream_set:stream_set(), stream_id(), hpack:headers()) -> ok.
 send_trailers(Streams, StreamId, Trailers) ->

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1623,7 +1623,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                case {
                                                                  h2_stream_set:recv_window_size(Stream) < L,
                                                                  Flow,
-                                                                 L > 0 andalso h2_stream_set:queued_data(Stream) /= done
+                                                                 L > 0
                                                                 } of
                                                                    {true, _, _} ->
                                                                        rst_stream__(Stream,

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -910,7 +910,8 @@ route_frame(
         false ->
             %% TODO: Priority Sort! Right now, it's just sorting on
             %% lowest stream_id first
-            Streams = h2_stream_set:sort(Conn#connection.streams),
+            %Streams = h2_stream_set:sort(Conn#connection.streams),
+            Streams = Conn#connection.streams,
 
             {RemainingSendWindow, UpdatedStreams} =
                 h2_stream_set:send_what_we_can(

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -761,6 +761,7 @@ route_frame(Event, {H, _Payload},
               }}, ok)
                                                               end);
         _X ->
+            ct:pal("closing because of unexpected settings value on ack"),
             maybe_reply(Event, {next_state, closing, Conn}, ok)
     end;
 
@@ -1289,6 +1290,7 @@ handle_event(info, {ssl_error, Socket, Reason},
     handle_socket_error(Reason, Conn);
 handle_event(info, {go_away, ErrorCode}, Conn) ->
     gen_statem:cast(self(), io_lib:format("GO_AWAY: ErrorCode ~p", [ErrorCode])),
+    ct:pal("sent goaway ~p", [ErrorCode]),
     {next_state, closing, Conn};
 %handle_event(info, {_,R},
 %           #connection{}=Conn) ->
@@ -1450,6 +1452,7 @@ go_away_(ErrorCode, Socket, Streams) ->
     go_away_(ErrorCode, <<>>, Socket, Streams).
 
 go_away_(ErrorCode, Reason, Socket, Streams) ->
+    ct:pal("sending goaway ~p ~p", [ErrorCode, Reason]),
     NAS = h2_stream_set:get_next_available_stream_id(Streams),
     GoAway = h2_frame_goaway:new(NAS, ErrorCode, Reason),
     GoAwayBin = h2_frame:to_binary({#frame_header{
@@ -1849,6 +1852,7 @@ start_http2_server(
              send_settings(Http2Settings, NewState)
             };
         {error, invalid_preface} ->
+            ct:pal("invalid preface"),
             {next_state, closing, Conn}
     end.
 
@@ -1895,6 +1899,7 @@ handle_socket_passive(Conn) ->
     {keep_state, Conn}.
 
 handle_socket_closed(Conn) ->
+    ct:pal("socket closed"),
     {stop, normal, Conn}.
 
 handle_socket_error(Reason, Conn) ->

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1506,8 +1506,8 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                        StreamId = Header#frame_header.stream_id,
                                        {#settings{max_frame_size=MFS}, _} = h2_stream_set:get_settings(St),
                                        case Header#frame_header.type of
-                                           _ when L > MFS ->
-                                               go_away_(?FRAME_SIZE_ERROR, S, St),
+                                           _ when L > MFS andalso false ->
+                                               go_away_(?FRAME_SIZE_ERROR, list_to_binary(io_lib:format("received frame of size ~p over max of ~p", [L, MFS])), S, St),
                                                Connection ! {go_away, ?FRAME_SIZE_ERROR};
                                            %% The first frame should be the client settings as per
                                            %% RFC-7540#3.5
@@ -1673,7 +1673,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                go_away_(?PROTOCOL_ERROR, <<"ping on stream /= 0">>, S, St),
                                                Connection ! {go_away, ?PROTOCOL_ERROR};
                                            ?PING when Header#frame_header.length /= 8 ->
-                                               go_away_(?FRAME_SIZE_ERROR, S, St),
+                                               go_away_(?FRAME_SIZE_ERROR, "Header length is length 8", S, St),
                                                Connection ! {go_away, ?FRAME_SIZE_ERROR};
                                            ?PING when ?NOT_FLAG((Header#frame_header.flags), ?FLAG_ACK) ->
                                                Ack = h2_frame_ping:ack(Payload),

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1519,9 +1519,11 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                        %% Make window size great again
                                                                        h2_frame_window_update:send(S,
                                                                                                    L, Header#frame_header.stream_id),
-                                                                       send_window_update(Connection, L),
+                                                                       %send_window_update(Connection, L),
                                                                        h2_stream_set:decrement_socket_recv_window(L, St),
                                                                        recv_data(Stream, Frame),
+                                                                       h2_frame_window_update:send(S, L, 0),
+                                                                       h2_stream_set:increment_socket_recv_window(L, St),
                                                                        F(S, St, false, Decoder);
                                                                    %% Either
                                                                    %% {false, auto, true} or
@@ -1564,9 +1566,6 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                        end,
                                                        F(S, St, false, NewDecoder)
                                                end;
-
-
-
                                            ?PRIORITY when StreamId == 0 ->
                                                go_away_(?PROTOCOL_ERROR, S, St);
                                            ?PRIORITY ->

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1611,8 +1611,8 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                          Streams),
                                                                        F(S, St, false, Decoder)
                                                                end;
-                                                           Type ->
-                                                               go_away_(?PROTOCOL_ERROR, list_to_binary(io_lib:format("data on ~p stream ~p", [Type, Header#frame_header.stream_id])), S, St),
+                                                           StreamType ->
+                                                               go_away_(?PROTOCOL_ERROR, list_to_binary(io_lib:format("data on ~p stream ~p", [StreamType, Header#frame_header.stream_id])), S, St),
                                                                Connection ! {go_away, ?PROTOCOL_ERROR}
                                                        end
                                                end;

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1403,6 +1403,7 @@ go_away_(ErrorCode, Socket, Streams) ->
     go_away_(ErrorCode, <<>>, Socket, Streams).
 
 go_away_(ErrorCode, Reason, Socket, Streams) ->
+    ct:pal("sending goaway ~p ~p", [ErrorCode, Reason]),
     NAS = h2_stream_set:get_next_available_stream_id(Streams),
     GoAway = h2_frame_goaway:new(NAS, ErrorCode, Reason),
     GoAwayBin = h2_frame:to_binary({#frame_header{

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -754,7 +754,7 @@ route_frame(Event, {H, _Payload},
 
             %% we have to change a bunch of stuff, so wait until we
             %% have the lock to do so
-            h2_stream_set:take_exclusive_lock(Streams, [streams, settings],
+            h2_stream_set:take_exclusive_lock(Streams, [settings],
                                               fun() ->
                                                       h2_stream_set:update_self_settings(Streams, NewSettings),
             UpdatedStreams1 =
@@ -1649,8 +1649,10 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                    _Tried ->
                                                                        recv_data(Stream, Frame),
                                                                        h2_stream_set:decrement_socket_recv_window(L, St),
-                                                                       h2_stream_set:upsert(
-                                                                         h2_stream_set:decrement_recv_window(L, Stream),
+                                                                       {ok, ok} = h2_stream_set:update(Header#frame_header.stream_id,
+                                                                                            fun(Str) ->
+                                                                                                    {h2_stream_set:decrement_recv_window(L, Str), ok}
+                                                                                            end,
                                                                          Streams),
                                                                        F(S, St, false, Decoder)
                                                                end;

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -936,7 +936,7 @@ route_frame(Event,
     Stream0 = h2_stream_set:get(StreamId, Streams),
     case h2_stream_set:type(Stream0) of
         idle ->
-            go_away(Event, ?PROTOCOL_ERROR, <<"window update on idle stream">>, Conn);
+            go_away(Event, ?PROTOCOL_ERROR, list_to_binary(io_lib:format("window update on idle stream ~p", [StreamId])), Conn);
         closed ->
             rst_stream_(Event, Stream0, ?STREAM_CLOSED, Conn);
         active ->
@@ -1623,7 +1623,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                case {
                                                                  h2_stream_set:recv_window_size(Stream) < L,
                                                                  Flow,
-                                                                 L > 0
+                                                                 L > 0 andalso h2_stream_set:queued_data(Stream) /= done
                                                                 } of
                                                                    {true, _, _} ->
                                                                        rst_stream__(Stream,
@@ -1676,7 +1676,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                              CallbackOpts,
                                                              Streams) of
                                                            {error, ErrorCode, NewStream} ->
-                                                               ct:pal("RST when creating stream ~p", [ErrorCode]),
+                                                               ct:pal("RST when creating stream ~p ~p", [StreamId, ErrorCode]),
                                                                rst_stream__(NewStream, ErrorCode, S),
                                                                none;
                                                            {_, _, _NewStreams} ->

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -1566,7 +1566,7 @@ spawn_data_receiver(Socket, Streams, Flow) ->
                                                                        F(S, St, false, Decoder)
                                                                end;
                                                            _ ->
-                                                               ct:pal("data on inactive stream"),
+                                                               ct:pal("data on inactive stream ~p", [Header#frame_header.stream_id]),
                                                                go_away_(?PROTOCOL_ERROR, <<"data on inactive stream">>, S, St),
                                                                Connection ! {go_away, ?PROTOCOL_ERROR}
                                                        end

--- a/src/h2_frame_goaway.erl
+++ b/src/h2_frame_goaway.erl
@@ -7,6 +7,7 @@
     error_code/1,
     format/1,
     new/2,
+    new/3,
     read_binary/2,
     to_binary/1
    ]).
@@ -35,6 +36,15 @@ new(StreamId, ErrorCode) ->
        last_stream_id = StreamId,
        error_code = ErrorCode
       }.
+
+-spec new(stream_id(), error_code(), binary()) -> payload().
+new(StreamId, ErrorCode, Reason) ->
+    #goaway{
+       last_stream_id = StreamId,
+       error_code = ErrorCode,
+       additional_debug_data = Reason
+      }.
+
 
 -spec read_binary(binary(), h2_frame:header()) ->
                          {ok, payload(), binary()}

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -799,9 +799,9 @@ closed(_, _,
 closed(Type, Event, State) ->
     handle_event(Type, Event, State).
 
-send_trailers(State, Trailers, Stream=#stream_state{connection=Conn,
+send_trailers(State, Trailers, Stream=#stream_state{streams=Streams,
                                                     stream_id=StreamId}) ->
-    h2_connection:actually_send_trailers(Conn, StreamId, Trailers),
+    h2_connection:actually_send_trailers(Streams, StreamId, Trailers),
     case State of
         half_closed_remote ->
             {next_state, closed, Stream, 0};

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -396,7 +396,7 @@ open(cast, recv_es,
                callback_state=NewCBState
               }};
         rst_stream ->
-            ct:pal("closing on ES with rst"),
+            ct:pal("stream ~p closing on ES with rst", [Stream#stream_state.stream_id]),
             {next_state,
              closed,
              Stream}
@@ -459,7 +459,7 @@ open(cast, {recv_data,
                 ok ->
                     {next_state, half_closed_remote, NewStream};
                 rst_stream ->
-                    ct:pal("closing on rst_stream"),
+                    ct:pal("stream ~p closing on rst_stream", [Stream#stream_state.stream_id]),
                     {next_state, closed, NewStream}
             end;
 
@@ -890,7 +890,7 @@ rst_stream_(ErrorCode,
                      },
                    RstStream}),
     sock:send(Socket, RstStreamBin),
-    ct:pal("closing on rst_stream ~p", [ErrorCode]),
+    ct:pal("stream ~p closing on rst_stream ~p", [StreamId, ErrorCode]),
     {next_state,
      closed,
      Stream, 0}.

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -601,7 +601,7 @@ half_closed_remote(cast,
         ok ->
             case ?IS_FLAG(Flags, ?FLAG_END_STREAM) of
                 true ->
-                    ct:pal("closing on END STREAM flag on data"),
+                    ct:pal("stream ~p closing on END STREAM flag on data ~p", [Stream#stream_state.stream_id, F]),
                     {next_state, closed, Stream, 0};
                 _ ->
                     {next_state, half_closed_remote, Stream}
@@ -682,7 +682,7 @@ half_closed_local(cast,
                 [h2_frame_data:data(Payload)
                  || {#frame_header{type=?DATA}, Payload} <- queue:to_list(NewQ)],
 
-                    ct:pal("closing on END STREAM flag on data"),
+                    ct:pal("stream ~p closing on END STREAM flag on data ~p", [Stream#stream_state.stream_id, F]),
             {next_state, closed,
              Stream#stream_state{
                incoming_frames=queue:new(),
@@ -700,7 +700,7 @@ half_closed_local(cast,
    {#frame_header{
        flags=Flags,
        type=?DATA
-      }, Payload}},
+      }, Payload}=F},
   #stream_state{
      callback_mod=CB,
      callback_state=CallbackState
@@ -710,7 +710,7 @@ half_closed_local(cast,
     case ?IS_FLAG(Flags, ?FLAG_END_STREAM) of
         true ->
             {ok, NewCBState1} = callback(CB, on_end_stream, [], NewCBState),
-                    ct:pal("closing on END STREAM flag on data"),
+            ct:pal("stream ~p closing on END STREAM flag on data ~p", [Stream#stream_state.stream_id, F]),
             {next_state, closed,
              Stream#stream_state{
                callback_state=NewCBState1

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -637,8 +637,9 @@ half_closed_remote(cast,
 
 half_closed_remote(_Type, {send_trailers, Trailers}, State) ->
     send_trailers(half_closed_remote, Trailers, State);
-half_closed_remote(cast, _,
+half_closed_remote(cast, _E,
        #stream_state{}=Stream) ->
+    ct:pal("stream closed on cast ~p", [_E]),
     rst_stream_(?STREAM_CLOSED, Stream);
 half_closed_remote(Type, Event, State) ->
     handle_event(Type, Event, State).
@@ -755,8 +756,9 @@ half_closed_local(cast, recv_es,
 half_closed_local(cast, {send_t, _Trailers},
                   #stream_state{}) ->
     keep_state_and_data;
-half_closed_local(_, _,
+half_closed_local(_T, _E,
        #stream_state{}=Stream) ->
+    ct:pal("stream closed on ~p ~p", [_T, _E]),
     rst_stream_(?STREAM_CLOSED, Stream);
 half_closed_local(Type, Event, State) ->
     handle_event(Type, Event, State).
@@ -802,8 +804,9 @@ closed(cast,
   #stream_state{connection=_Pid,
                 stream_id=_StreamId}=Stream) ->
    {keep_state,Stream#stream_state{response_trailers=Headers}, 0};
-closed(_, _,
+closed(_T, _E,
        #stream_state{}=Stream) ->
+    ct:pal("stream closed on ~p ~p", [_T, _E]),
     rst_stream_(?STREAM_CLOSED, Stream);
 closed(Type, Event, State) ->
     handle_event(Type, Event, State).

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -766,6 +766,7 @@ closed(timeout, _,
                                         StreamState#stream_state.response_trailers}
                                        %{client, true} -> garbage
                 end,
+                ct:pal("closing closed stream ~p on timeout", [StreamId]),
                 {_NewStream, _NewStreams} =
                 h2_stream_set:close(
                   Stream,

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -887,6 +887,7 @@ rst_stream_(ErrorCode,
                      },
                    RstStream}),
     sock:send(Socket, RstStreamBin),
+    ct:pal("closing on rst_stream ~p", [ErrorCode]),
     {next_state,
      closed,
      Stream, 0}.

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -722,7 +722,7 @@ half_closed_local(cast, recv_es,
                     } = Stream) ->
     {ok, NewCBState} = callback(CB, on_end_stream, [], CallbackState),
     Data = [h2_frame_data:data(Payload) || {#frame_header{type=?DATA}, Payload} <- queue:to_list(Q)],
-    ct:pal("stream ~p received ES"),
+    ct:pal("stream ~p received ES", [Stream#stream_state.stream_id]),
     {next_state, closed,
      Stream#stream_state{
        incoming_frames=queue:new(),

--- a/src/h2_stream.erl
+++ b/src/h2_stream.erl
@@ -603,6 +603,7 @@ half_closed_remote(cast,
                     {next_state, half_closed_remote, Stream}
             end;
         {error,_} ->
+            ct:pal("closing on socket send error"),
             {next_state, closed, Stream, 0}
     end;
 half_closed_remote(cast,
@@ -625,6 +626,7 @@ half_closed_remote(cast,
                     {next_state, half_closed_remote, Stream}
             end;
         {error,_} ->
+            ct:pal("closing on socket send error"),
             {next_state, closed, Stream, 0}
     end;
 
@@ -720,6 +722,7 @@ half_closed_local(cast, recv_es,
                     } = Stream) ->
     {ok, NewCBState} = callback(CB, on_end_stream, [], CallbackState),
     Data = [h2_frame_data:data(Payload) || {#frame_header{type=?DATA}, Payload} <- queue:to_list(Q)],
+    ct:pal("stream ~p received ES"),
     {next_state, closed,
      Stream#stream_state{
        incoming_frames=queue:new(),

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -1157,7 +1157,8 @@ my_max_active(SS) ->
 their_max_active(SS) ->
     (get_their_peers(SS))#peer_subset.max_active.
 
-take_lock(StreamSet, Locks, Fun) ->
+take_lock(StreamSet, Locks0, Fun) ->
+    Locks = Locks0 -- [socket],
     [ take_lock(lock_to_index(Lock), StreamSet) || Lock <- lists:sort(Locks) ],
     Res = catch Fun(),
     [ release_lock(lock_to_index(Lock), StreamSet) || Lock <- lists:sort(Locks) ],
@@ -1185,7 +1186,8 @@ take_lock(Index, StreamSet=#stream_set{atomics=Atomics}) ->
             take_lock(Index, StreamSet)
     end.
 
-take_exclusive_lock(StreamSet, Locks, Fun) ->
+take_exclusive_lock(StreamSet, Locks0, Fun) ->
+    Locks = Locks0 -- [socket],
     LockRes = [ {take_exclusive_lock(lock_to_index(Lock), StreamSet), lock_to_index(Lock)} || Lock <- lists:sort(Locks) ],
     case lists:all(fun({Res, _Index}) -> Res == ok end, LockRes) of
         false ->

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -150,6 +150,7 @@
     stream_pid/1,
     notify_pid/1,
     type/1,
+    stream_set_type/1,
     my_active_count/1,
     their_active_count/1,
     my_active_streams/1,
@@ -813,6 +814,10 @@ pid(#active_stream{pid=Pid}) ->
     Pid;
 pid(_) ->
     undefined.
+
+-spec stream_set_type(stream_set()) -> client | server.
+stream_set_type(StreamSet) ->
+    StreamSet#stream_set.type.
 
 -spec type(stream()) -> idle | active | closed.
 type(#idle_stream{}) ->

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -969,7 +969,7 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
             end,
 
             {Frames, SentBytes, NewS} =
-            case MaxToSend > QueueSize of
+            case MaxToSend >= QueueSize of
                 true ->
                     EndStream = case Stream#active_stream.body_complete of
                                     true ->
@@ -988,6 +988,7 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
                        queued_data=done,
                        send_window_size=SSWS-QueueSize}};
                 false ->
+                    ct:pal("taking ~p of ~p", [MaxToSend, byte_size(Stream#active_stream.queued_data)]),
                     <<BinToSend:MaxToSend/binary,Rest/binary>> = Stream#active_stream.queued_data,
                     {chunk_to_frames(BinToSend, MFS, Stream#active_stream.id, false, []),
                      MaxToSend,

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -972,6 +972,8 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
                     {max(0, SSWS), stream}
             end,
 
+            ct:pal("max to send on ~p is ~p -- SWS ~p SSWS ~p", [StreamId, MaxToSend, SWS, SSWS]),
+
             {Frames, SentBytes, NewS} =
             case MaxToSend >= QueueSize of
                 _ when MaxToSend == 0 ->

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -931,7 +931,7 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
             ignore;
        (#active_stream{queued_data=Data, pid=Pid, trailers=Trailers}=S) when is_atom(Data) ->
             NewS = S#active_stream{trailers=undefined},
-            {NewS, {0, [{send_trailers, Pid, Trailers}]}};
+            {NewS, S, {0, [{send_trailers, Pid, Trailers}]}};
        (#active_stream{}=Stream) ->
 
             %% We're coming in here with three numbers we need to look at:

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -517,13 +517,15 @@ upsert(#idle_stream{}, StreamSet) ->
 upsert(Stream, StreamSet) ->
     StreamId = stream_id(Stream),
     PeerSubset = get_peer_subset(StreamId, StreamSet),
-    case upsert_peer_subset(Stream, PeerSubset, StreamSet) of
+    try upsert_peer_subset(Stream, PeerSubset, StreamSet) of
         {error, Code} ->
             {error, Code};
         unchanged ->
             StreamSet;
         NewPeerSubset ->
             set_peer_subset(StreamId, StreamSet, NewPeerSubset)
+    catch _:_ ->
+              StreamSet
     end.
 
 -spec upsert_peer_subset(

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -252,6 +252,7 @@ new_stream(
         false ->
             {ok, Pid} = h2_stream:start_link(
                        StreamId,
+                       StreamSet,
                        self(),
                        CBMod,
                        CBOpts,

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -1249,7 +1249,7 @@ their_max_active(SS) ->
     (get_their_peers(SS))#peer_subset.max_active.
 
 take_lock(StreamSet, Locks0, Fun) ->
-    Locks = Locks0 -- [socket],
+    Locks = Locks0 -- [socket, streams],
     [ take_lock(lock_to_index(Lock), StreamSet) || Lock <- lists:sort(Locks) ],
     Res = Fun(),
     [ release_lock(lock_to_index(Lock), StreamSet) || Lock <- lists:sort(Locks) ],
@@ -1292,7 +1292,7 @@ take_lock(Index, StreamSet=#stream_set{atomics=Atomics}) ->
     end.
 
 take_exclusive_lock(StreamSet, Locks0, Fun) ->
-    Locks = Locks0 -- [socket],
+    Locks = Locks0 -- [socket, streams],
     LockRes = [ {take_exclusive_lock(lock_to_index(Lock), StreamSet), lock_to_index(Lock)} || Lock <- lists:sort(Locks) ],
     case lists:all(fun({Res, _Index}) -> Res == ok end, LockRes) of
         false ->

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -34,7 +34,7 @@
 
      connection :: pid(),
 
-     table = ets:new(?MODULE, [public, {keypos, 2}]) :: ets:tab(),
+     table = ets:new(?MODULE, [public, {keypos, 2}, {read_concurrency, true}, {write_concurrency, true}]) :: ets:tab(),
      %% Streams initiated by this peer
      %% mine :: peer_subset(),
      %% Streams initiated by the other peer
@@ -505,6 +505,7 @@ get_from_subset(Id, _PeerSubset, StreamSet) ->
                 [] ->
                     #closed_stream{id=Id};
                 [NewStream] ->
+                    ct:pal("found missing stream ~p", [Id]),
                     NewStream
             catch _:_ ->
                       ct:pal("returning closed stream for ~p on ets crasj", [Id]),

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -323,6 +323,7 @@ new_stream(
          PeerSubset#peer_subset.active_count >= PeerSubset#peer_subset.max_active
     of
         true ->
+            ct:pal("refused stream ~p because of max active", [StreamId]),
             {error, ?REFUSED_STREAM, #closed_stream{id=StreamId}};
         false ->
             {ok, Pid} = case self() == StreamSet#stream_set.connection of
@@ -352,6 +353,7 @@ new_stream(
                           },
             case upsert(NewStream, StreamSet) of
                 {error, ?REFUSED_STREAM} ->
+                    ct:pal("refused stream ~p", [StreamId]),
                     %% This should be very rare, if it ever happens at
                     %% all. The case clause above tests the same
                     %% condition that upsert/2 checks to return this
@@ -364,6 +366,7 @@ new_stream(
                     h2_stream:stop(Pid),
                     {error, ?REFUSED_STREAM, #closed_stream{id=StreamId}};
                 NewStreamSet ->
+                    ct:pal("inserted stream ~p", [StreamId]),
                     {Pid, StreamId, NewStreamSet}
             end
     end.
@@ -509,14 +512,12 @@ get_from_subset(Id, _PeerSubset, StreamSet) ->
                     ct:pal("found missing stream ~p", [Id]),
                     NewStream
             catch _:_ ->
-                      ct:pal("returning closed stream for ~p on ets crasj", [Id]),
                       #closed_stream{id=Id}
             end;
         [Stream] ->
             Stream
     catch
         _:_ ->
-            ct:pal("returning closed stream for ~p on ets crasj", [Id]),
             #closed_stream{id=Id}
     end.
 

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -15,6 +15,8 @@
      %% Type determines which streams are mine, and which are theirs
      type :: client | server,
 
+     recv_window_size = atomics:new(1, []),
+
      table = ets:new(?MODULE, [public, {keypos, 2}]) :: ets:tab()
      %% Streams initiated by this peer
      %% mine :: peer_subset(),
@@ -136,6 +138,10 @@
     update_data_queue/3,
     decrement_recv_window/2,
     recv_window_size/1,
+    decrement_socket_recv_window/2,
+    increment_socket_recv_window/2,
+    socket_recv_window_size/1,
+    set_socket_recv_window_size/2,
     response/1,
     send_window_size/1,
     increment_send_window_size/2,
@@ -877,6 +883,18 @@ decrement_recv_window(
      };
 decrement_recv_window(_, S) ->
     S.
+
+decrement_socket_recv_window(L, #stream_set{recv_window_size = Window}) ->
+    atomics:sub(Window, 1, L).
+
+increment_socket_recv_window(L, #stream_set{recv_window_size = Window}) ->
+    atomics:add(Window, 1, L).
+
+socket_recv_window_size(#stream_set{recv_window_size = Window}) ->
+    atomics:get(Window, 1).
+
+set_socket_recv_window_size(Value, #stream_set{recv_window_size = Window}) ->
+    atomics:put(Window, 1, Value).
 
 send_window_size(#active_stream{send_window_size=SWS}) ->
     SWS;

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -488,6 +488,7 @@ get_from_subset(Id,
                    lowest_stream_id=Lowest
                   }, _StreamSet)
   when Id < Lowest ->
+    ct:pal("returning closed stream for ~p id < lowest", [Id]),
     #closed_stream{id=Id};
 get_from_subset(Id,
                 #peer_subset{
@@ -498,11 +499,13 @@ get_from_subset(Id,
 get_from_subset(Id, _PeerSubset, StreamSet) ->
     try ets:lookup(StreamSet#stream_set.table, Id)  of
         [] ->
+            ct:pal("returning closed stream for ~p unknown", [Id]),
             #closed_stream{id=Id};
         [Stream] ->
             Stream
     catch
         _:_ ->
+            ct:pal("returning closed stream for ~p on ets crasj", [Id]),
             #closed_stream{id=Id}
     end.
 

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -503,7 +503,7 @@ get_from_subset(Id,
 get_from_subset(Id, _PeerSubset, StreamSet) ->
     try ets:lookup(StreamSet#stream_set.table, Id)  of
         [] ->
-            ct:pal("returning closed stream for ~p unknown", [Id]),
+            ct:pal("returning closed stream ~p for unknown", [Id]),
             timer:sleep(100),
             try ets:lookup(StreamSet#stream_set.table, Id)  of
                 [] ->

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -501,7 +501,15 @@ get_from_subset(Id, _PeerSubset, StreamSet) ->
         [] ->
             ct:pal("returning closed stream for ~p unknown", [Id]),
             timer:sleep(100),
-            get_from_subset(Id, _PeerSubset, StreamSet);
+            try ets:lookup(StreamSet#stream_set.table, Id)  of
+                [] ->
+                    #closed_stream{id=Id};
+                [NewStream] ->
+                    NewStream
+            catch _:_ ->
+                      ct:pal("returning closed stream for ~p on ets crasj", [Id]),
+                      #closed_stream{id=Id}
+            end;
         [Stream] ->
             Stream
     catch

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -931,7 +931,7 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
             ignore;
        (#active_stream{queued_data=Data, pid=Pid, trailers=Trailers}=S) when is_atom(Data) ->
             NewS = S#active_stream{trailers=undefined},
-            {NewS, S, {0, [{send_trailers, Pid, Trailers}]}};
+            {NewS, {0, S, [{send_trailers, Pid, Trailers}]}};
        (#active_stream{}=Stream) ->
 
             %% We're coming in here with three numbers we need to look at:

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -494,11 +494,14 @@ get_from_subset(Id,
   when Id >= Next ->
     #idle_stream{id=Id};
 get_from_subset(Id, _PeerSubset, StreamSet) ->
-    case ets:lookup(StreamSet#stream_set.table, Id)  of
+    try ets:lookup(StreamSet#stream_set.table, Id)  of
         [] ->
             #closed_stream{id=Id};
         [Stream] ->
             Stream
+    catch
+        _:_ ->
+            #closed_stream{id=Id}
     end.
 
 -spec upsert(

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -1040,11 +1040,11 @@ s_send_what_we_can(MFS, StreamId, StreamFun0, Streams) ->
             NewSWS = decrement_socket_send_window(BytesSent, Streams),
             case BytesSent > NewSWS of
                 true ->
-                    ct:pal("OVERSENT ~p > ~p on ~p", [BytesSent, NewSWS, StreamId]),
                     %% we delved too deep, and too greedily
                     %% try to roll things back
                     ets:insert(Streams#stream_set.table, StreamFun0(OldStream)),
                     SWS = increment_socket_send_window(BytesSent, Streams),
+                    ct:pal("OVERSENT ~p > ~p on ~p -- reset to ~p", [BytesSent, NewSWS, SWS, StreamId]),
                     SWS;
                 false ->
                     ct:pal("sent ~p on ~p", [BytesSent, StreamId]),

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -500,7 +500,8 @@ get_from_subset(Id, _PeerSubset, StreamSet) ->
     try ets:lookup(StreamSet#stream_set.table, Id)  of
         [] ->
             ct:pal("returning closed stream for ~p unknown", [Id]),
-            #closed_stream{id=Id};
+            timer:sleep(100),
+            get_from_subset(Id, _PeerSubset, StreamSet);
         [Stream] ->
             Stream
     catch

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -389,7 +389,9 @@ update_peer_settings(StreamSet, Settings) ->
     ets:insert(StreamSet#stream_set.table, #connection_settings{type=peer_settings, settings=Settings}).
 
 get_encode_context(StreamSet) ->
-    (hd(ets:lookup(StreamSet#stream_set.table, encode_context)))#context.context.
+    try (hd(ets:lookup(StreamSet#stream_set.table, encode_context)))#context.context
+    catch _:_ -> hpack:new_context()
+    end.
 
 update_encode_context(StreamSet, Context) ->
     ets:insert(StreamSet#stream_set.table, #context{type=encode_context, context=Context}).
@@ -414,7 +416,7 @@ get_peer_subset(Id, StreamSet) ->
 get_my_peers(StreamSet) ->
     Next = atomics:get(StreamSet#stream_set.atomics, ?MY_NEXT_AVAILABLE_STREAM_ID),
     try (hd(ets:lookup(StreamSet#stream_set.table, mine)))#peer_subset{next_available_stream_id=Next}
-    catch _:_ -> hpack:new_context()
+    catch _:_ -> #peer_subset{}
     end.
 
 -spec get_their_peers(stream_set()) -> peer_subset().

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -318,6 +318,7 @@ new_stream(
                                      {get_peer_subset(Id, StreamSet), Id}
                              end,
 
+    ct:pal("spawning stream ~p", [StreamId]),
     case PeerSubset#peer_subset.max_active =/= unlimited andalso
          PeerSubset#peer_subset.active_count >= PeerSubset#peer_subset.max_active
     of

--- a/src/h2_stream_set.erl
+++ b/src/h2_stream_set.erl
@@ -318,7 +318,7 @@ new_stream(
                                      {get_peer_subset(Id, StreamSet), Id}
                              end,
 
-    ct:pal("spawning stream ~p", [StreamId]),
+    ct:pal("~p spawning stream ~p", [StreamSet#stream_set.type, StreamId]),
     case PeerSubset#peer_subset.max_active =/= unlimited andalso
          PeerSubset#peer_subset.active_count >= PeerSubset#peer_subset.max_active
     of
@@ -366,7 +366,7 @@ new_stream(
                     h2_stream:stop(Pid),
                     {error, ?REFUSED_STREAM, #closed_stream{id=StreamId}};
                 NewStreamSet ->
-                    ct:pal("inserted stream ~p", [StreamId]),
+                    ct:pal("~p inserted stream ~p", [StreamSet#stream_set.type, StreamId]),
                     {Pid, StreamId, NewStreamSet}
             end
     end.
@@ -492,7 +492,7 @@ get_from_subset(Id,
                    lowest_stream_id=Lowest
                   }, _StreamSet)
   when Id < Lowest ->
-    ct:pal("returning closed stream for ~p id < lowest", [Id]),
+    ct:pal("~p returning closed stream for ~p id < lowest", [_StreamSet#stream_set.type, Id]),
     #closed_stream{id=Id};
 get_from_subset(Id,
                 #peer_subset{
@@ -503,7 +503,7 @@ get_from_subset(Id,
 get_from_subset(Id, _PeerSubset, StreamSet) ->
     try ets:lookup(StreamSet#stream_set.table, Id)  of
         [] ->
-            ct:pal("returning closed stream ~p for unknown", [Id]),
+            ct:pal("~p returning closed stream ~p for unknown", [StreamSet#stream_set.type, Id]),
             timer:sleep(100),
             try ets:lookup(StreamSet#stream_set.table, Id)  of
                 [] ->

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -132,8 +132,10 @@ basic_push(_Config) ->
 wait_for_n_notifications(0) ->
     ok;
 wait_for_n_notifications(N) ->
+    ct:pal("test waiting for END_STREAM on ~p", [self()]),
     receive
         {'END_STREAM', _} ->
+            ct:pal("got END_STREAM ~p", [N]),
             wait_for_n_notifications(N-1);
         _ ->
             wait_for_n_notifications(N)

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -115,7 +115,7 @@ basic_push(_Config) ->
     %% We'll know we're done when we're notified of all the streams ending.
     wait_for_n_notifications(12),
 
-    Streams = h2_connection:get_streams(Client),
+    Streams = Client,
     ct:pal("Streams ~p", [Streams]),
     ?assertEqual(0, (h2_stream_set:my_active_count(Streams))),
     ?assertEqual(0, (h2_stream_set:their_active_count(Streams))),

--- a/test/client_server_SUITE.erl
+++ b/test/client_server_SUITE.erl
@@ -115,6 +115,8 @@ basic_push(_Config) ->
     %% We'll know we're done when we're notified of all the streams ending.
     wait_for_n_notifications(12),
 
+    timer:sleep(1000),
+
     Streams = Client,
     ct:pal("Streams ~p", [Streams]),
     ?assertEqual(0, (h2_stream_set:my_active_count(Streams))),

--- a/test/double_body_handler.erl
+++ b/test/double_body_handler.erl
@@ -10,6 +10,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -49,6 +50,10 @@ on_end_stream(State=#state{conn_pid=ConnPid,
     h2_connection:send_body(ConnPid, StreamId, <<"BodyPart1\n">>,
                             [{send_end_stream, false}]),
     h2_connection:send_body(ConnPid, StreamId, <<"BodyPart2">>),
+    {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("handle_info(~p, ~p)", [Event, State]),
     {ok, State}.
 
 terminate(_State) ->

--- a/test/echo_handler.erl
+++ b/test/echo_handler.erl
@@ -10,6 +10,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -50,6 +51,10 @@ on_end_stream(State=#state{conn_pid=ConnPid,
                       ],
     h2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
     h2_connection:send_body(ConnPid, StreamId, Buffer),
+    {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("handle_info(~p, ~p)", [Event, State]),
     {ok, State}.
 
 terminate(_State) ->

--- a/test/flow_control_handler.erl
+++ b/test/flow_control_handler.erl
@@ -12,6 +12,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -52,6 +53,10 @@ on_end_stream(State=#state{conn_pid=ConnPid,
                             [{send_end_stream, false}]),
     timer:sleep(200),
     h2_connection:send_body(ConnPid, StreamId, crypto:strong_rand_bytes(?SEND_BYTES)),
+    {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("handle_info(~p, ~p)", [Event, State]),
     {ok, State}.
 
 terminate(_State) ->

--- a/test/http2_spec_5_1_SUITE.erl
+++ b/test/http2_spec_5_1_SUITE.erl
@@ -86,6 +86,7 @@ total_streams_above_max_concurrent(Config) ->
     %% should be open
 
     Resp0 = http2c:get_frames(Client,0),
+    timer:sleep(1000),
     ?assertEqual([], Resp0),
     [ begin
           [{FH1,_FB1},{FH2,_FB2}] = http2c:get_frames(Client, StreamId),

--- a/test/http2c.erl
+++ b/test/http2c.erl
@@ -69,6 +69,7 @@ send_binary(Pid, Binary) ->
 %% ifdef(TEST)
 -spec send_unaltered_frames(pid(), [h2_frame:frame()]) -> ok.
 send_unaltered_frames(Pid, Frames) ->
+    ct:pal("sending frames ~p", [Frames]),
     [send_binary(Pid, h2_frame:to_binary(F)) || F <- Frames],
     ok.
 
@@ -193,6 +194,7 @@ handle_cast(recv, #http2c_state{
     RawBody = Transport:recv(Socket, FHeader#frame_header.length),
     {ok, Payload, <<>>} = h2_frame:read_binary_payload(RawBody, FHeader),
     F = {FHeader, Payload},
+    ct:pal("http2c received ~p", [F]),
     gen_server:cast(self(), recv),
     {noreply, State#http2c_state{incoming_frames = Frames ++ [F]}};
 handle_cast({encode_context, EC}, State=#http2c_state{}) ->

--- a/test/peer_test_handler.erl
+++ b/test/peer_test_handler.erl
@@ -10,6 +10,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -53,6 +54,10 @@ on_end_stream(State=#state{conn_pid=ConnPid,
                       ],
     h2_connection:send_headers(ConnPid, StreamId, ResponseHeaders),
     h2_connection:send_body(ConnPid, StreamId, Body),
+    {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("handle_info(~p, ~p)", [Event, State]),
     {ok, State}.
 
 terminate(_State) ->

--- a/test/server_connection_receive_window.erl
+++ b/test/server_connection_receive_window.erl
@@ -8,6 +8,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -34,6 +35,10 @@ on_receive_data(Bin, State)->
 
 on_end_stream(State) ->
     ct:pal("on_end_stream(~p)", [State]),
+    {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("handle_info(~p, ~p)", [Event, State]),
     {ok, State}.
 
 terminate(_State) ->

--- a/test/server_stream_receive_window.erl
+++ b/test/server_stream_receive_window.erl
@@ -8,6 +8,7 @@
          on_send_push_promise/2,
          on_receive_data/2,
          on_end_stream/1,
+         handle_info/2,
          terminate/1
         ]).
 
@@ -35,6 +36,11 @@ on_receive_data(_Bin, State)->
 on_end_stream(State) ->
     ct:pal("on_end_stream(~p)", [State]),
     {ok, State}.
+
+handle_info(Event, State) ->
+    ct:pal("handle_info(~p, ~p)", [Event, State]),
+    {ok, State}.
+
 
 terminate(_State) ->
     ok.


### PR DESCRIPTION
This PR attempts to optimize stream handling in chatterbox. A few things are done:

* StreamSet is made into an ETS table so that it can be shared between processes
* Socket receive is moved to its own process
* Whenever possible, the socket receive process sends messages directly to the stream process
* Reduce the number of messages the connection process has to handle (window updates, stream_finish, etc)
* Make the recv window an atomic counter so both the connection and the receiver can update it